### PR TITLE
No Seperator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@yellowcard/phone-input-component",
-  "version": "1.3.0",
+  "version": "1.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yellowcard/phone-input-component",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Yellowcard UI component module for retrieving a user's phone number.",
   "author": "Merdoth <ucheya97@gmail.com>",
   "main": "./dist/phoneInput.common.js",

--- a/src/components/PhoneInput.vue
+++ b/src/components/PhoneInput.vue
@@ -79,7 +79,7 @@ export default {
       this.inputValue = `+${val} `;
     },
     inputValue: function(val) {
-      let formattedValue = val.replace(/[^0-9\+\-\s]/g, "");
+      let formattedValue = val.replace(/[^0-9\+\s]/g, "");
       if (!formattedValue.startsWith(`+${this.callingCode} `))
         formattedValue = this.phoneNumber;
       this.phoneNumber = this.inputValue = formattedValue;


### PR DESCRIPTION
## Problem
With different people of different nationalle having different mindset as to how phone numbers should be formatted, it becomes hard to get users past the phone-number entry stage without errors. e.g, some Nigerians could input his phone number as `+234 813 248 1231`, another would write thesame number as `+234 81 324 812 31`. 

## Solution
Make phone number return plain string without user formatting. so regardless of what the user enters, the raw phone number would be returned without `-` or space.